### PR TITLE
Remove file extension from imported css

### DIFF
--- a/app/assets/stylesheets/activeadmin/_quill_editor_input.sass
+++ b/app/assets/stylesheets/activeadmin/_quill_editor_input.sass
@@ -1,4 +1,4 @@
-@import 'activeadmin/quill_editor/quill.snow.css'
+@import 'activeadmin/quill_editor/quill.snow'
 
 body.active_admin form .quill-editor
   display: inline-block


### PR DESCRIPTION
Hey!
While using the editor, we found out the the theme stylesheet was 404'ing in prod builds. We tracked it to the import. When importing with an extension, this will generate a normal css import, which will work locally, but not when the assets are build for production, since it will stay as a simple css import instead of the file being included by sprocket in the build.

Thanks for the plugin! ⭐️ 