### PR TITLE
Don't send useless tags if editor blank

### DIFF
--- a/app/assets/javascripts/activeadmin/quill_editor_input.js
+++ b/app/assets/javascripts/activeadmin/quill_editor_input.js
@@ -38,7 +38,11 @@ var initQuillEditors = function() {
     formtastic.onsubmit = function() {
       for(var i = 0; i < editors.length; i++) {
         var input = editors[i].querySelector('input[type="hidden"]');
-        input.value = editors[i]['_quill-editor'].root.innerHTML;
+        if (editors[i]['_quill-editor'].editor.isBlank()) {
+          input.value = '';
+        } else {
+          input.value = editors[i]['_quill-editor'].root.innerHTML;
+        }
       }
     };
   }


### PR DESCRIPTION
Hi @blocknotes!

I have found that this plugin sends useless tags `<p><br></p>` when editor is empty.
I investigated and found these tags are generated by Quill. There is issue [#1235](https://github.com/quilljs/quill/issues/1235).
I think we should check editor content and send an empty string on submit if editor is empty.
With this problem we can't validate a input on presence because it always has value.

I think my PR will resolved it.
Thank you for good plugin.