### PR TITLE
Webpacker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ An Active Admin plugin to use [Quill Rich Text Editor](https://github.com/quillj
 ![screenshot](screenshot.png)
 
 ## Install
-- After installing Active Admin, add to your Gemfile: `gem 'activeadmin_quill_editor'` (and execute *bundle*)
+After installing Active Admin, add to your Gemfile: `gem 'activeadmin_quill_editor'` (and execute *bundle*)
+
+If you installed Active Admin without Webpacker support (default for now):
+
 - Add at the end of your Active Admin styles (_app/assets/stylesheets/active_admin.scss_):
 ```scss
 @import 'activeadmin/quill_editor/quill.snow';
@@ -16,13 +19,23 @@ An Active Admin plugin to use [Quill Rich Text Editor](https://github.com/quillj
 //= require activeadmin/quill_editor/quill
 //= require activeadmin/quill_editor_input
 ```
-- Use the input with `as: :quill_editor` in Active Admin model conf
-
-Why 2 separated scripts/styles? In this way you can include a different version of *quill editor* if you like.
 
 > **UPDATE FROM VERSION <= 2.0**: please add to your _app/assets/stylesheets/active_admin.scss_ the line `@import 'activeadmin/quill_editor/quill.snow';`
 
-## Options
+If you installed Active Admin with Webpacker support:
+
+- Execute in your project root:
+```sh
+yarn add blocknotes/activeadmin_quill_editor
+```
+- Add to your *app/javascript/packs/active_admin.js*:
+```js
+require('activeadmin_quill_editor')
+```
+
+## Usage
+In your Active Admin models, form configuration, set the text inputs with `as: :quill_editor` where needed.
+
 **data-options**: permits to set *quill editor* options directly - see [options list](https://quilljs.com/docs/configuration/)
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+// Styles
+import 'activeadmin_quill_editor/app/assets/stylesheets/activeadmin/quill_editor/quill.snow'
+import 'activeadmin_quill_editor/app/assets/stylesheets/activeadmin/_quill_editor_input'
+
+// JS
+window.Quill = require('activeadmin_quill_editor/app/assets/javascripts/activeadmin/quill_editor/quill')
+require('activeadmin_quill_editor/app/assets/javascripts/activeadmin/quill_editor_input')

--- a/lib/activeadmin/quill_editor/version.rb
+++ b/lib/activeadmin/quill_editor/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveAdmin
   module QuillEditor
-    VERSION = '0.2.14'
+    VERSION = '0.3.0'
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "activeadmin_quill_editor",
+  "version": "0.3.0",
+  "description": "Quill Editor for ActiveAdmin",
+  "author": "Mattia Roccoberton <mat@blocknot.es>",
+  "license": "MIT",
+  "homepage": "https://github.com/blocknotes/activeadmin_quill_editor",
+  "main": "index.js"
+}


### PR DESCRIPTION
Add Webpacker support - related to #12.

### Test procedure
- Execute: `yarn add blocknotes/activeadmin_quill_editor#feature/webpacker-support`
- Add to **app/javascript/packs/active_admin.js**: `require('activeadmin_quill_editor')`

### Extra notes
- When the gem is updated also `yarn install` must be executed again => TODO: update the README