### PR TITLE
Allow ActiveAdmin 3

### DIFF
--- a/activeadmin_quill_editor.gemspec
+++ b/activeadmin_quill_editor.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['{app,lib}/**/*', 'LICENSE.txt', 'Rakefile', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activeadmin', '~> 2.0'
+  spec.add_runtime_dependency 'activeadmin', '>= 2.0, < 4'
 
   spec.add_development_dependency 'appraisal', '~> 2.4'
 end

--- a/activeadmin_quill_editor.gemspec
+++ b/activeadmin_quill_editor.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['{app,lib}/**/*', 'LICENSE.txt', 'Rakefile', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activeadmin', '>= 2.0, < 4'
+  spec.add_runtime_dependency 'activeadmin', '>= 2.0', '< 4'
 
   spec.add_development_dependency 'appraisal', '~> 2.4'
 end

--- a/gemfiles/rails52_activeadmin20.gemfile.lock
+++ b/gemfiles/rails52_activeadmin20.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin_quill_editor (1.0.0)
-      activeadmin (~> 2.0)
+      activeadmin (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails60_activeadmin.gemfile.lock
+++ b/gemfiles/rails60_activeadmin.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin_quill_editor (1.0.0)
-      activeadmin (~> 2.0)
+      activeadmin (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails60_activeadmin22.gemfile.lock
+++ b/gemfiles/rails60_activeadmin22.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin_quill_editor (1.0.0)
-      activeadmin (~> 2.0)
+      activeadmin (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails61_activeadmin.gemfile.lock
+++ b/gemfiles/rails61_activeadmin.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin_quill_editor (1.0.0)
-      activeadmin (~> 2.0)
+      activeadmin (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails61_activeadmin29.gemfile.lock
+++ b/gemfiles/rails61_activeadmin29.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin_quill_editor (1.0.0)
-      activeadmin (~> 2.0)
+      activeadmin (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails70_activeadmin.gemfile.lock
+++ b/gemfiles/rails70_activeadmin.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     activeadmin_quill_editor (1.0.0)
-      activeadmin (~> 2.0)
+      activeadmin (>= 2.0, < 4)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
**ActiveAdmin 3.0 has been released** but the update is blocked for me due this gem does not support it.

Let's relax the condition to support ActiveAdmin 3.