### PR TITLE
Add check to prevent GET request for non-existent image after upload

### DIFF
--- a/app/assets/javascripts/activeadmin/quill_editor_input.js
+++ b/app/assets/javascripts/activeadmin/quill_editor_input.js
@@ -73,6 +73,9 @@
             method: 'POST'
           }).then(response => response.json())
             .then(result => {
+              if (!result.url) {
+                reject('Upload failed')
+              }
               resolve(result.url);
             })
             .catch(error => {


### PR DESCRIPTION
## Description:
This update adds a check to prevent a GET request from being sent for a non-existent image URL when image upload validation fails

**Changes:**

- Added a check to reject the request if the image URL is empty (reject('Upload failed')), avoiding unnecessary GET requests for non-existent images.